### PR TITLE
Fix Java model imports generation for Jakarta

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -29,8 +29,8 @@ import android.os.Parcel;
 {{/parcelableModel}}
 {{#useBeanValidation}}
 {{#jakarta}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 {{/jakarta}}
 {{^jakarta}}
 import javax.validation.constraints.*;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes a copy/paste error in the Java model template where the jakarta branch uses the same old javax imports as the non-jakarta branch.

I currently can't run the descriped shell script, please sb clone this, run the script and push changes to this PR branch, if any - Thanks.